### PR TITLE
support for offset clause

### DIFF
--- a/python_soql_parser/core.py
+++ b/python_soql_parser/core.py
@@ -25,9 +25,9 @@ from python_soql_parser.binops import EQ, GT, GTE, LT, LTE, NEQ
 ParserElement.enablePackrat()
 
 select_statement = Forward()
-SELECT, FROM, WHERE, AND, OR, IN, NULL, TRUE, FALSE, LIMIT, ORDER, BY, DESC, ASC = map(
+SELECT, FROM, WHERE, AND, OR, IN, NULL, TRUE, FALSE, LIMIT, OFFSET, ORDER, BY, DESC, ASC = map(
     CaselessKeyword,
-    "select from where and or in null true false limit order by desc asc".split(),
+    "select from where and or in null true false limit offset order by desc asc".split(),
 )
 
 identifier = Word(alphas, alphanums + "_" + ".").setName("identifier")
@@ -59,6 +59,8 @@ where_clause = Optional(Suppress(WHERE) + where_expression, None)
 
 limit_clause = Optional(Suppress(LIMIT) + int_num, None)
 
+offset_clause = Optional(Suppress(OFFSET) + int_num, None)
+
 ordering_term = Group(field_name + Optional(ASC | DESC)("direction"))
 
 order_clause = Optional(
@@ -74,6 +76,7 @@ select_statement <<= (
     + where_clause("where")
     + order_clause("order_by")
     + limit_clause("limit")
+    + offset_clause("offset")
 )
 
 soql = select_statement
@@ -85,6 +88,7 @@ class SoqlQuery(TypedDict):
     sobject: str
     where: Any
     limit: Any
+    offset: Any
 
 
 def parse(soql_query: str) -> SoqlQuery:

--- a/tests/test_python_soql_parser.py
+++ b/tests/test_python_soql_parser.py
@@ -86,6 +86,35 @@ def test_query_with_limit(query, sobject, fields, limit):
 
 
 @pytest.mark.parametrize(
+    "query,sobject,fields,offset",
+    [
+        ("Select Id FROM Contact OFFSET 1", "Contact", ["Id"], [1]),
+        ("Select Id FROM Contact OFFSET 99", "Contact", ["Id"], [99]),
+    ],
+)
+def test_query_with_offset(query, sobject, fields, offset):
+    parsed = parse(query)
+    assert parsed["sobject"] == sobject
+    assert parsed["fields"].asList() == fields
+    assert parsed["offset"].asList() == offset
+
+
+@pytest.mark.parametrize(
+    "query,sobject,fields,limit,offset",
+    [
+        ("Select Id FROM Contact LIMIT 10 OFFSET 1", "Contact", ["Id"], [10], [1]),
+        ("Select Id FROM Contact LIMIT 1 OFFSET 99", "Contact", ["Id"], [1], [99]),
+    ],
+)
+def test_query_with_limit_offset(query, sobject, fields, limit, offset):
+    parsed = parse(query)
+    assert parsed["sobject"] == sobject
+    assert parsed["fields"].asList() == fields
+    assert parsed["limit"].asList() == limit
+    assert parsed["offset"].asList() == offset
+
+
+@pytest.mark.parametrize(
     "query,sobject,fields,order",
     [
         (


### PR DESCRIPTION
ultimate goal: test code that uses soql selects with offset clause via simple-salesforce + simple-mockforce
https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_offset.htm
